### PR TITLE
Add floating terminal button

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,42 @@
+/* Floating terminal window */
+#terminal-window {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  width: 600px;
+  height: 400px;
+  border: 1px solid #333;
+  background: #111;
+  z-index: 1000;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+  display: none;
+  resize: both;
+  overflow: hidden;
+}
+#terminal-window iframe {
+  width: 100%;
+  height: calc(100% - 30px);
+  border: 0;
+}
+#terminal-header {
+  cursor: grab;
+  background: #333;
+  color: #fff;
+  padding: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 30px;
+}
+#terminal-header.grabbing { cursor: grabbing; }
+#terminal-close {
+  background: transparent;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.terminal-button {
+  cursor: pointer;
+}

--- a/hugo.toml
+++ b/hugo.toml
@@ -34,6 +34,9 @@ paginationSize = 100
 listSummaries = true
 listDateFormat = '2 Jan 2006'
 
+# URL used for the floating terminal window
+terminalURL = 'https://terminal.example.dev'
+
 # Breadcrumbs
 [params.breadcrumbs]
 enabled = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="{{ or site.Language.LanguageCode site.Language.Lang }}"
+  dir="{{ or site.Language.LanguageDirection `ltr` }}">
+
+<head>
+  {{ partial "head.html" . }}
+</head>
+
+{{ $theme := "auto"}}
+
+{{ with .Param "theme" }}
+{{ $theme = .}}
+{{ end }}
+
+<body class="{{ $theme }}">
+
+  <div class="content">
+    <header>
+      {{ partial "header.html" . }}
+    </header>
+
+    <main class="main">
+      {{ block "main" . }}{{ end }}
+    </main>
+  </div>
+
+  {{/* Body end hook */}}
+  {{ partial "functions/get_hook.html" (dict "hook" "body_end" "context" .) }}
+
+  <footer>
+    {{ partial "footer.html" . }}
+  </footer>
+
+  {{ if .Param "math" }}
+  {{ partialCached "math.html" . }}
+  {{ end }}
+</body>
+
+<script src="{{ "js/theme-switch.js" | relURL }}"></script>
+<script defer src="{{ "js/copy-code.js" | relURL }}"></script>
+<script defer src="{{ "js/terminal-window.js" | relURL }}"></script>
+</html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,36 @@
+{{/* Header */}}
+
+<div class="header">
+
+    {{ if or (not (.Param "hideHeader")) .IsHome }}
+
+    <h1 class="header-title">
+        <a href="{{ site.BaseURL }}">{{ site.Title }}</a>
+    </h1>
+
+    <div class="header-menu">
+        {{ $currentPage := . }}
+
+        {{ with site.Params.menu }}
+        {{ range . }}
+
+        <p
+            class="small {{ if eq .name (lower $currentPage.Name) }} bold {{end}}">
+            <a href="{{ .url }}" {{ if and (isset . "newTab") .newTab
+                }}target="_blank" rel="noopener noreferrer" {{ end }}>
+                /{{.name }}
+            </a>
+        </p>
+        {{ end }}
+        {{ end }}
+
+        {{ with site.Params.terminalURL }}
+        <p class="small">
+            <a href="#" id="terminal-button" class="terminal-button" data-url="{{ . }}">/terminal</a>
+        </p>
+        {{ end }}
+    </div>
+
+    {{ end }}
+
+</div>

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,0 +1,94 @@
+{{- /*
+  Original source: https://github.com/gohugoio/hugo/blob/61c39ae63b62667d965c2ff96d085f4eda59bcb2/tpl/tplimpl/embedded/templates/opengraph.html
+*/ -}}
+
+<meta property="og:url" content="{{ .Permalink }}">
+
+{{- with or site.Title site.Params.title | plainify }}
+  <meta property="og:site_name" content="{{ . }}">
+{{- end }}
+
+{{- /* Source modified to remove pipe to `plainify` */ -}}
+{{- with or .Title site.Title site.Params.title }}
+  <meta property="og:title" content="{{ . }}">
+{{- end }}
+
+{{- with or .Description .Summary site.Params.description | plainify | htmlUnescape }}
+  <meta property="og:description" content="{{ trim . "\n\r\t " }}">
+{{- end }}
+
+{{- with or .Params.locale site.Language.LanguageCode }}
+  <meta property="og:locale" content="{{ replace . `-` `_` }}">
+{{- end }}
+
+{{- if .IsPage }}
+  <meta property="og:type" content="article">
+  {{- with .Section }}
+    <meta property="article:section" content="{{ . }}">
+  {{- end }}
+  {{- $ISO8601 := "2006-01-02T15:04:05-07:00" }}
+  {{- with .PublishDate }}
+    <meta property="article:published_time" {{ .Format $ISO8601 | printf "content=%q" | safeHTMLAttr }}>
+  {{- end }}
+  {{- with .Lastmod }}
+    <meta property="article:modified_time" {{ .Format $ISO8601 | printf "content=%q" | safeHTMLAttr }}>
+  {{- end }}
+  {{- range .GetTerms "tags" | first 6 }}
+    <meta property="article:tag" content="{{ .Page.Title | plainify }}">
+  {{- end }}
+{{- else }}
+  <meta property="og:type" content="website">
+{{- end }}
+
+{{- with partial "_funcs/get-page-images" . }}
+  {{- range . | first 6 }}
+    <meta property="og:image" content="{{ .Permalink }}">
+  {{- end }}
+{{- else }}
+
+  {{- /*
+    Source modified to load `assets/images/og-image.{webp,png,jpg}` files if any of them exists.
+    og-image.html can be modified in Hugo project if custom image generation logic is desired such
+    as using an external service.
+  */ -}}
+
+  {{- if templates.Exists "partials/head/og-image.html" }}
+    {{- $ogImage := trim (partial "head/og-image.html" .) "\n\r\t " }}
+    {{- with $ogImage }}
+      <meta property="og:image" content="{{ . }}">
+    {{- end }}
+  {{- end }}
+  
+{{- end }}
+
+{{- with .Params.audio }}
+  {{- range . | first 6  }}
+    <meta property="og:audio" content="{{ . | absURL }}">
+  {{- end }}
+{{- end }}
+
+{{- with .Params.videos }}
+  {{- range . | first 6 }}
+    <meta property="og:video" content="{{ . | absURL }}">
+  {{- end }}
+{{- end }}
+
+{{- range .GetTerms "series" }}
+  {{- range .Pages | first 7 }}
+    {{- if ne $ . }}
+      <meta property="og:see_also" content="{{ .Permalink }}">
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- with site.Params.social }}
+  {{- if reflect.IsMap . }}
+    {{- with .facebook_app_id }}
+      <meta property="fb:app_id" content="{{ . }}">
+    {{- else }}
+      {{- with .facebook_admin }}
+        <meta property="fb:admins" content="{{ . }}">
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/static/js/terminal-window.js
+++ b/static/js/terminal-window.js
@@ -1,0 +1,51 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const btn = document.getElementById("terminal-button");
+  if (!btn) return;
+
+  const overlay = document.createElement("div");
+  overlay.id = "terminal-window";
+  overlay.innerHTML = `
+    <div id="terminal-header">
+      <span>Terminal</span>
+      <button id="terminal-close" aria-label="Close terminal">×</button>
+    </div>
+    <iframe id="terminal-iframe" src="" loading="lazy"></iframe>
+  `;
+  document.body.appendChild(overlay);
+
+  const iframe = overlay.querySelector("#terminal-iframe");
+  const closeBtn = overlay.querySelector("#terminal-close");
+
+  overlay.style.display = "none";
+  iframe.src = btn.dataset.url || "https://terminal.example.dev";
+
+  btn.addEventListener("click", function (e) {
+    e.preventDefault();
+    overlay.style.display = "block";
+  });
+
+  closeBtn.addEventListener("click", function () {
+    overlay.style.display = "none";
+  });
+
+  const header = overlay.querySelector("#terminal-header");
+  let offsetX = 0;
+  let offsetY = 0;
+  let isDown = false;
+
+  header.addEventListener("mousedown", function (e) {
+    isDown = true;
+    offsetX = overlay.offsetLeft - e.clientX;
+    offsetY = overlay.offsetTop - e.clientY;
+    header.classList.add("grabbing");
+  });
+  document.addEventListener("mouseup", function () {
+    isDown = false;
+    header.classList.remove("grabbing");
+  });
+  document.addEventListener("mousemove", function (e) {
+    if (!isDown) return;
+    overlay.style.left = e.clientX + offsetX + "px";
+    overlay.style.top = e.clientY + offsetY + "px";
+  });
+});


### PR DESCRIPTION
## Summary
- add a terminalURL parameter in hugo.toml
- override header partial to show a Terminal button
- override base layout to load a new script
- override opengraph partial for compatibility
- add JS and CSS for a movable terminal iframe

## Testing
- `apt-get update`
- `apt-get install -y hugo`
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_684f879b3b808321870a59dba06823f9