### PR TITLE
Adjust terminal dimensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ COPY Longitud_Tuberia.m .
 
 EXPOSE 8080
 CMD ["gotty", "--permit-write", "--port", "8080", \
-      "bash", "-lc", "octave --persist Longitud_Tuberia.m 2>/dev/null"]
+     "--width", "98", "--height", "28", \
+     "bash", "-lc", "octave --persist Longitud_Tuberia.m 2>/dev/null"]

--- a/Longitud_Tuberia.m
+++ b/Longitud_Tuberia.m
@@ -12,14 +12,14 @@ if a >= b, error('a debe ser < b'); end
 integrand   = @(x) sqrt(1 + (dy_dx(x)).^2);
 arc_length = integral(integrand, a, b);
 
-xv = linspace(a,b,80);
+xv = linspace(a,b,98);
 yv = y(xv);
 
 tmp = [tempname() '.dat'];
 dlmwrite(tmp, [xv' yv'], ' ');
 
 cmd = sprintf([
-    'gnuplot -e "set terminal dumb size 80,20; ', ...
+    'gnuplot -e "set terminal dumb size 98,28; ', ...
     'set title \\"y(x)=0.5x^2\\"; ', ...
     'plot ''%s'' using 1:2 with lines"'], tmp);
 


### PR DESCRIPTION
## Summary
- set Gotty terminal size to 98x28 in Dockerfile
- use 98 columns and 28 rows for the gnuplot ASCII plot in Longitud_Tuberia.m

## Testing
- `hugo --minify`
- `go mod tidy`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6850ef219c588321b019106a2ade44f6