### PR TITLE
Fix terminal overlay size

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3,8 +3,9 @@
   position: fixed;
   top: 20px;
   left: 20px;
-  width: 600px;
-  height: 400px;
+  /* Sized to match the 98x28 character terminal */
+  width: 880px;
+  height: 460px;
   border: 1px solid #333;
   background: #111;
   z-index: 1000;


### PR DESCRIPTION
## Summary
- tweak CSS for floating terminal window so the dimensions match a 98x28 terminal

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68516225e1a48321842e4faa97455cad