### PR TITLE
Add terminal button for exercise posts

### DIFF
--- a/content/posts/post.md
+++ b/content/posts/post.md
@@ -12,6 +12,7 @@ tags: ["MATLAB", "gnuplot", "Cálculo", "Longitud de arco", "ASCII Art"]
 showTags: false
 hideBackToTop: false
 fediverse: "@username@instance.url"
+exercise: tuberia.m
 ---
 
 ¿Alguna vez te has preguntado cómo calcular la longitud de una tubería curva a partir de su función matemática? En este post exploraremos cómo hacerlo con MATLAB, utilizando gráficos en ASCII con `gnuplot` para una visualización directa desde la terminal.

--- a/hugo.toml
+++ b/hugo.toml
@@ -36,7 +36,7 @@ listDateFormat = '2 Jan 2006'
 
 # URL used for the floating terminal window
 # The value is taken from the environment variable `HUGO_TERMINAL_URL`.
-terminalURL = getenv "HUGO_TERMINAL_URL"
+terminalURL = "$HUGO_TERMINAL_URL"
 
 # Breadcrumbs
 [params.breadcrumbs]

--- a/hugo.toml
+++ b/hugo.toml
@@ -35,7 +35,8 @@ listSummaries = true
 listDateFormat = '2 Jan 2006'
 
 # URL used for the floating terminal window
-terminalURL = 'https://docker-octave-test.happyisland-2e46231f.eastus.azurecontainerapps.io'
+# The value is taken from the environment variable `HUGO_TERMINAL_URL`.
+terminalURL = getenv "HUGO_TERMINAL_URL"
 
 # Breadcrumbs
 [params.breadcrumbs]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,124 @@
+{{ define "main" }}
+
+{{/* Breadcrumbs */}}
+
+{{ if not .IsHome }}
+{{ partial "breadcrumbs.html" . }}
+{{ end }}
+
+<div {{ if .Param "autonumber" }} class="autonumber" {{ end }}>
+  <article>
+    <header class="single-intro-container">
+        {{- /* Title and Summary */}}
+        
+        <h1 class="single-title">{{ .Title }}</h1>
+        {{- with .Param "summary" }}
+        <p class="single-summary">{{ . | markdownify }}</p>
+        {{- end }}
+   
+        {{- /* Date, Reading Time and Author */}}
+        {{ if or (or (.Param "author") (.Param "authorAvatarPath")) (or .Date (.Param "readTime")) }}
+        <div class="single-subsummary">
+          {{ with $.Param "authorAvatarPath" }}
+            <img src="{{ . }}" alt="Author Avatar" />
+          {{ end }}
+          <div>
+            {{ with .Param "author" }}
+            <p class="author"> {{- .}} </p>
+            {{ end }}
+            <p class="single-date">
+            {{- with .Date }}
+              {{- $dateMachine := . | time.Format "2006-01-02T15:04:05-07:00" }}
+              {{- $dateHuman := . | time.Format (default ":date_long" $.Site.Params.singleDateFormat) }}
+              <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+            {{- end }}
+        
+            {{- if .Param "readTime" }}
+              &nbsp; · &nbsp;
+              {{- .ReadingTime }} min read
+            {{- end }}
+            </p>
+          </div>
+        </div>
+        {{- end}}
+        
+    </header>
+
+    {{ with .Param "exercise" }}
+      <p class="exercise-button">
+        <a href="{{ $.Site.Params.terminalURL }}/?arg={{ . }}" target="_blank" rel="noopener">
+          Abrir terminal
+        </a>
+      </p>
+    {{ end }}
+    
+    {{- if .Param "showTags" }}
+      {{- $taxonomy := "tags" }}
+      {{- with .Param $taxonomy }}    
+        <div class="single-tags">
+            {{- range $index, $tag := . }}
+            {{- with $.Site.GetPage (printf "/%s/%s" $taxonomy $tag) -}}
+                <span>
+                  <a href="{{ .Permalink }}">#{{ .LinkTitle }}</a>
+                </span>
+            {{- end }}
+            {{- end }}
+        </div>
+      {{- end }}
+    {{- end }}
+    
+    {{- /* Table of Contents */}}
+    
+    {{- if .Param "toc" }}
+      <aside class="toc">
+        <p><strong>Table of contents</strong></p>
+        {{ .TableOfContents }}
+      </aside>
+    {{- end }}
+    
+    {{- /* Page content */}}
+    
+    <div class="single-content">
+      {{ .Content }}
+    </div>
+  </article>
+  
+  {{- /* Comments */}}
+
+  {{- if and .Site.Params.giscus.enable (not .Params.disableComment) }}
+    <div class="single-comments">
+      {{ partial "comments.html" . }}
+    </div>
+  {{- end }}
+
+  {{ if .Store.Get "hasMermaid" }}
+  {{ $mermaidDarkTheme := default "dark" (or .Params.mermaidDarkTheme .Site.Params.mermaidDarkTheme) }}
+  {{ $mermaidTheme := default "default" (or .Params.mermaidTheme .Site.Params.mermaidTheme) }}
+  <script defer
+    type="module"
+    id="mermaid_script"
+    data-light-theme="{{ $mermaidTheme }}"
+    data-dark-theme="{{ $mermaidDarkTheme }}"
+    src='{{ "js/mermaid.js" | relURL }}'>
+  </script>
+  {{ end }}
+
+  {{/* Next prev controls */}}
+
+  {{ if not (.Param "hidePagination") }}
+  {{ partial "pagination-single.html" . }}
+  {{ end }}
+
+  {{/* Back to top */}}
+
+  {{ if not (.Param "hideBackToTop") }}
+  <div class="back-to-top">
+    <a href="#top">
+      back to top
+    </a>
+  </div>
+  {{ end }}
+
+</div>
+
+{{ end }}


### PR DESCRIPTION
## Summary
- show a button to open an Octave terminal when `exercise` is set in front matter
- pull terminal URL from the `HUGO_TERMINAL_URL` environment variable
- update example post with an exercise

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68699b0372088321bfb35a8fdf37b802