### PR TITLE
Show terminal button only for exercise posts

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -24,9 +24,10 @@
         {{ end }}
         {{ end }}
 
-        {{ with site.Params.terminalURL }}
+        {{ $terminalURL := site.Params.terminalURL }}
+        {{ if and $terminalURL (.Param "exercise") }}
         <p class="small">
-            <a href="#" id="terminal-button" class="terminal-button" data-url="{{ . }}">/terminal</a>
+            <a href="#" id="terminal-button" class="terminal-button" data-url="{{ $terminalURL }}">/terminal</a>
         </p>
         {{ end }}
     </div>


### PR DESCRIPTION
## Summary
- show terminal button only when posts declare an `exercise` parameter

## Testing
- `hugo --minify` *(fails: partial `head.html` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a80e8f78832181a538d2b4e6c5a0