### PR TITLE
Add auto-open for exercise terminal

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -25,10 +25,12 @@
         {{ end }}
 
         {{ $terminalURL := site.Params.terminalURL }}
-        {{ if and $terminalURL (.Param "exercise") }}
+        {{ with .Param "exercise" }}
+        {{ if $terminalURL }}
         <p class="small">
-            <a href="#" id="terminal-button" class="terminal-button" data-url="{{ $terminalURL }}">/terminal</a>
+            <a href="#" id="terminal-button" class="terminal-button" data-url="{{ printf "%s/?arg=%s" $terminalURL . }}" data-auto-open="true">/terminal</a>
         </p>
+        {{ end }}
         {{ end }}
     </div>
 

--- a/static/js/terminal-window.js
+++ b/static/js/terminal-window.js
@@ -50,6 +50,10 @@ document.addEventListener("DOMContentLoaded", function () {
     show();
   });
 
+  if (btn.dataset.autoOpen === "true") {
+    show();
+  }
+
   closeBtn.addEventListener("click", hide);
   if (minimizeBtn) {
     minimizeBtn.addEventListener("click", hide);


### PR DESCRIPTION
## Summary
- auto-open the terminal overlay when a post has an exercise
- pass the exercise filename to the terminal via header button

## Testing
- `go fmt ./...` *(no packages)*

------
https://chatgpt.com/codex/tasks/task_e_6869bb6eba8c8321b98ab58978fab0c2