### PR TITLE
Stop auto-opening exercise terminal

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -28,7 +28,7 @@
         {{ with .Param "exercise" }}
         {{ if $terminalURL }}
         <p class="small">
-            <a href="#" id="terminal-button" class="terminal-button" data-url="{{ printf "%s/?arg=%s" $terminalURL . }}" data-auto-open="true">/terminal</a>
+            <a href="#" id="terminal-button" class="terminal-button" data-url="{{ printf "%s/?arg=%s" $terminalURL . }}">/terminal</a>
         </p>
         {{ end }}
         {{ end }}

--- a/static/js/terminal-window.js
+++ b/static/js/terminal-window.js
@@ -50,9 +50,7 @@ document.addEventListener("DOMContentLoaded", function () {
     show();
   });
 
-  if (btn.dataset.autoOpen === "true") {
-    show();
-  }
+
 
   closeBtn.addEventListener("click", hide);
   if (minimizeBtn) {


### PR DESCRIPTION
## Summary
- open terminal overlay with the exercise URL but don't auto-launch

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6869bf7da17883219195242d1924f362