### PR TITLE
Set default terminal URL

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -35,8 +35,8 @@ listSummaries = true
 listDateFormat = '2 Jan 2006'
 
 # URL used for the floating terminal window
-# The value is taken from the environment variable `HUGO_TERMINAL_URL`.
-terminalURL = "$HUGO_TERMINAL_URL"
+# Points to the public Octave environment used for interactive code
+terminalURL = "https://octave-env.happyisland-2e46231f.eastus.azurecontainerapps.io"
 
 # Breadcrumbs
 [params.breadcrumbs]


### PR DESCRIPTION
## Summary
- ensure the terminal link uses the Octave environment URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869c33d37b0832190d0b70f4f5773f2