### PR TITLE
Add split terminal layout

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -29,8 +29,35 @@
 }
 #terminal-window iframe {
   width: 100%;
-  height: calc(100% - 30px);
+  height: 100%;
   border: 0;
+}
+
+#terminal-container {
+  display: flex;
+  height: calc(100% - 30px);
+}
+
+#variables-panel {
+  width: 200px;
+  min-width: 120px;
+  max-width: 50%;
+  overflow: auto;
+  background: #222;
+  color: #0f0;
+  font-family: monospace;
+  padding: 4px;
+}
+
+#drag-handle {
+  width: 5px;
+  cursor: ew-resize;
+  background: #444;
+}
+
+#console-panel {
+  flex-grow: 1;
+  overflow: hidden;
 }
 #terminal-header {
   cursor: grab;

--- a/static/js/terminal-window.js
+++ b/static/js/terminal-window.js
@@ -12,11 +12,19 @@ document.addEventListener("DOMContentLoaded", function () {
         <button id="terminal-close" aria-label="Close terminal">×</button>
       </div>
     </div>
-    <iframe id="terminal-iframe" src="" loading="lazy"></iframe>
+    <div id="terminal-container">
+      <div id="variables-panel"></div>
+      <div id="drag-handle"></div>
+      <div id="console-panel">
+        <iframe id="terminal-iframe" src="" loading="lazy"></iframe>
+      </div>
+    </div>
   `;
   document.body.appendChild(overlay);
 
   const iframe = overlay.querySelector("#terminal-iframe");
+  const variablesPanel = overlay.querySelector("#variables-panel");
+  const dragHandle = overlay.querySelector("#drag-handle");
   const closeBtn = overlay.querySelector("#terminal-close");
   const minimizeBtn = overlay.querySelector("#terminal-minimize");
 
@@ -36,6 +44,7 @@ document.addEventListener("DOMContentLoaded", function () {
   function hide() {
     overlay.classList.remove("show");
     overlay.classList.add("minimized");
+    variablesPanel.innerHTML = "";
   }
 
   overlay.addEventListener("transitionend", function () {
@@ -78,5 +87,52 @@ document.addEventListener("DOMContentLoaded", function () {
     if (!isDown) return;
     overlay.style.left = e.clientX + offsetX + "px";
     overlay.style.top = e.clientY + offsetY + "px";
+  });
+
+  /* Resizable split panels */
+  let resizing = false;
+  dragHandle.addEventListener("pointerdown", function (e) {
+    resizing = true;
+    document.body.classList.add("no-select");
+  });
+  document.addEventListener("pointerup", function () {
+    if (resizing) {
+      resizing = false;
+      document.body.classList.remove("no-select");
+    }
+  });
+  document.addEventListener("pointermove", function (e) {
+    if (!resizing) return;
+    const containerRect = overlay
+      .querySelector("#terminal-container")
+      .getBoundingClientRect();
+    const newWidth = e.clientX - containerRect.left;
+    const minWidth = 120;
+    const maxWidth = containerRect.width * 0.5;
+    const width = Math.max(minWidth, Math.min(maxWidth, newWidth));
+    variablesPanel.style.width = width + "px";
+  });
+
+  /* Request variable list from iframe after Enter */
+  function requestVariables() {
+    try {
+      iframe.contentWindow.postMessage({ type: "getVariables" }, "*");
+    } catch (err) {
+      // ignored
+    }
+  }
+
+  window.addEventListener("message", function (e) {
+    if (e.data && e.data.type === "variables") {
+      const vars = Array.isArray(e.data.payload) ? e.data.payload : [];
+      variablesPanel.innerHTML =
+        "<ul>" + vars.map((v) => `<li>${v}</li>`).join("") + "</ul>";
+    }
+  });
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" && overlay.classList.contains("show")) {
+      requestVariables();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add left panel for variables next to terminal iframe
- make layout resizable via drag handle
- attempt to sync variables with the terminal via postMessage

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869e071ddb48321bc1a0ddaf5add47d