### PR TITLE
Add persistent Octave console input

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -28,7 +28,7 @@
         {{ with .Param "exercise" }}
         {{ if $terminalURL }}
         <p class="small">
-            <a href="#" id="terminal-button" class="terminal-button" data-url="{{ printf "%s/?arg=%s" $terminalURL . }}">/terminal</a>
+            <a href="#" id="terminal-button" class="terminal-button" data-url="{{ printf "/console/?backend=%s&arg=%s" $terminalURL . }}">/terminal</a>
         </p>
         {{ end }}
         {{ end }}

--- a/static/console/index.html
+++ b/static/console/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Consola Octave</title>
+<style>
+  body {margin:0;display:flex;flex-direction:column;height:100vh;font-family:monospace;}
+  #output-container {flex:1;overflow-y:auto;padding:4px;}
+  #input-container {border-top:1px solid #ccc;padding:4px;}
+  #command-input {width:100%;box-sizing:border-box;font-family:monospace;height:2em;}
+</style>
+</head>
+<body>
+<div id="output-container"><pre id="output"></pre></div>
+<div id="input-container">
+  <input id="command-input" type="text" aria-label="Campo de entrada de comandos" autocomplete="off">
+</div>
+<script id="auth-script"></script>
+<script src="/js/console.js"></script>
+</body>
+</html>

--- a/static/js/console.js
+++ b/static/js/console.js
@@ -1,0 +1,90 @@
+(function(){
+  const params = new URLSearchParams(window.location.search);
+  const backend = params.get('backend') || 'https://octave-env.happyisland-2e46231f.eastus.azurecontainerapps.io';
+  params.delete('backend');
+  const search = params.toString();
+  const wsUrl = backend.replace(/^http/, 'ws') + '/ws' + (search ? '?' + search : '');
+  const authScript = document.getElementById('auth-script');
+  authScript.src = backend + '/auth_token.js';
+
+  const outputEl = document.getElementById('output');
+  const inputEl = document.getElementById('command-input');
+  let ws = null;
+  let pingTimer = null;
+  let history = [];
+  let histIndex = 0;
+  let queue = [];
+  let open = false;
+
+  function connect(callback){
+    ws = new WebSocket(wsUrl, ['gotty']);
+    ws.addEventListener('open', ()=>{
+      open = true;
+      ws.send(JSON.stringify({Arguments: search ? '?' + search : '', AuthToken: window.gotty_auth_token || ''}));
+      pingTimer = setInterval(()=>{if(ws.readyState===1) ws.send('1');}, 30000);
+      if(queue.length){
+        queue.forEach(cmd=>ws.send('0'+cmd+'\n'));
+        queue = [];
+      }
+      if(callback) callback();
+    });
+    ws.addEventListener('message', (e)=>{
+      const type = e.data[0];
+      const data = e.data.slice(1);
+      if(type==='0') appendOutput(atob(data));
+    });
+    ws.addEventListener('close', ()=>{
+      open = false;
+      clearInterval(pingTimer);
+      appendOutput('\n[conexión cerrada]\n');
+    });
+  }
+
+  function appendOutput(text){
+    outputEl.textContent += text;
+    outputEl.parentElement.scrollTop = outputEl.parentElement.scrollHeight;
+  }
+
+  function sendCommand(cmd){
+    if(!cmd) return;
+    history.push(cmd);
+    histIndex = history.length;
+    if(open && ws.readyState===1){
+      ws.send('0'+cmd+'\n');
+    } else {
+      queue.push(cmd);
+      if(!open){
+        connect();
+      }
+    }
+  }
+
+  inputEl.addEventListener('keydown', function(e){
+    if(e.key==='Enter'){
+      e.preventDefault();
+      const cmd = inputEl.value;
+      inputEl.value='';
+      sendCommand(cmd);
+    } else if(e.key==='ArrowUp'){
+      e.preventDefault();
+      if(histIndex>0){
+        histIndex--; inputEl.value = history[histIndex];
+      }
+    } else if(e.key==='ArrowDown'){
+      e.preventDefault();
+      if(histIndex < history.length-1){
+        histIndex++; inputEl.value = history[histIndex];
+      } else { histIndex = history.length; inputEl.value=''; }
+    } else if(e.key==='Escape' || (e.key==='l' && e.ctrlKey)){
+      e.preventDefault();
+      outputEl.textContent='';
+    }
+  });
+
+  inputEl.addEventListener('blur', ()=> setTimeout(()=> inputEl.focus(), 0));
+
+  window.addEventListener('load', ()=>{
+    connect();
+    inputEl.focus();
+  });
+})();

--- a/static/js/terminal-window.js
+++ b/static/js/terminal-window.js
@@ -34,7 +34,9 @@ document.addEventListener("DOMContentLoaded", function () {
   function show() {
     overlay.style.display = "block";
     if (!iframeLoaded) {
-      iframe.src = btn.dataset.url || "https://octave-env.happyisland-2e46231f.eastus.azurecontainerapps.io/";
+      iframe.src =
+        btn.dataset.url ||
+        "/console/?backend=https://octave-env.happyisland-2e46231f.eastus.azurecontainerapps.io";
       iframeLoaded = true;
     }
     overlay.classList.remove("minimized");


### PR DESCRIPTION
## Summary
- include a custom `/console/` page with a fixed input bar
- connect to the Octave backend via websocket in `console.js`
- update the terminal overlay to load the new console page by default
- update header link to point to the new console UI

## Testing
- `apt-get install -y hugo`
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_6869e71525848321879a07c5b379239a